### PR TITLE
Fix: numbers showing 0%

### DIFF
--- a/apps/davi/src/stores/modules/SnapshotERC20Guild/fetchers/rpc/useTotalLocked.ts
+++ b/apps/davi/src/stores/modules/SnapshotERC20Guild/fetchers/rpc/useTotalLocked.ts
@@ -1,19 +1,13 @@
 import { useContractRead } from 'wagmi';
 import { BigNumber } from 'ethers';
-import { useHookStoreProvider } from 'stores';
 import { useListenToLockAndWithdrawTokens } from '../../events/useListenToLockAndWithdrawTokens';
 import { SnapshotERC20Guild } from 'contracts/ts-files/SnapshotERC20Guild';
+import { useSnapshotId } from 'stores/modules/common/fetchers';
 
 export const useTotalLocked = (
   guildAddress: string,
   proposalId?: `0x${string}`
 ) => {
-  const {
-    hooks: {
-      fetchers: { useSnapshotId },
-    },
-  } = useHookStoreProvider();
-
   const { data: snapshotId } = useSnapshotId({
     contractAddress: guildAddress,
     proposalId,

--- a/apps/davi/src/stores/modules/SnapshotRepGuild/fetchers/rpc/useTotalLocked.ts
+++ b/apps/davi/src/stores/modules/SnapshotRepGuild/fetchers/rpc/useTotalLocked.ts
@@ -19,7 +19,7 @@ export const useTotalLocked = (
   const { data: guildTokenAddress } = useGuildToken(guildAddress);
 
   const { data: snapshotId } = useSnapshotId({
-    contractAddress: guildTokenAddress,
+    contractAddress: guildAddress,
     proposalId,
   });
 

--- a/apps/davi/src/stores/modules/SnapshotRepGuild/fetchers/rpc/useTotalLocked.ts
+++ b/apps/davi/src/stores/modules/SnapshotRepGuild/fetchers/rpc/useTotalLocked.ts
@@ -1,21 +1,15 @@
 import { BigNumber } from 'ethers';
 import { useContractRead } from 'wagmi';
-import { useHookStoreProvider } from 'stores';
 import { BaseERC20Guild } from 'contracts/ts-files/BaseERC20Guild';
 import { ERC20SnapshotRep } from 'contracts/ts-files/ERC20SnapshotRep';
 import useGuildToken from 'Modules/Guilds/Hooks/useGuildToken';
 import { useListenToTokenTransfer } from '../../events/useListenToTokenTransfer';
+import { useSnapshotId } from 'stores/modules/common/fetchers';
 
 export const useTotalLocked = (
   guildAddress: string,
   proposalId?: `0x${string}`
 ) => {
-  const {
-    hooks: {
-      fetchers: { useSnapshotId },
-    },
-  } = useHookStoreProvider();
-
   const { data: guildTokenAddress } = useGuildToken(guildAddress);
 
   const { data: snapshotId } = useSnapshotId({

--- a/apps/davi/src/stores/modules/SnapshotRepGuild/index.ts
+++ b/apps/davi/src/stores/modules/SnapshotRepGuild/index.ts
@@ -13,6 +13,7 @@ export const snapshotRepGuildImplementation: Readonly<FullGovernanceImplementati
     bytecodes: [
       '0x5220f03f768c7f09437ccf760eb5307dc60f60e18c9c9ff9599a9ab3ad71d2a0',
       '0xb33418b664bfb6eba3ea37a77429d95daee4f0ab24f47ee63c4669340c4aae5a',
+      '0x56735be1df2293bbbc687502a3673244d05fac86940394cb2222ea884f304daf',
       config.bytecodeHash as `0x${string}`,
       config.deployedBytecodeHash as `0x${string}`,
     ],


### PR DESCRIPTION
## Description

Fixes numbers in votes or quorum showing either `null` or zero.

The `useTotalLocked` was calling `useSnapshotId` with the token address instead of the guild address. That returned null, and if the `snapshotId` was null, it used the current amount of tokens instead of the amount of tokens at the time of the creation of the proposal. It rounded to 0 because the current total amount of tokens is way bigger than it was at the time of the proposal creation.

Before: 
![image](https://user-images.githubusercontent.com/75996796/211642627-4b155a49-f087-4878-aa0c-f7443d3c7e32.png)


Now:
![image](https://user-images.githubusercontent.com/75996796/211642551-3f519b43-ec3e-4a6c-8aa3-2d92f3e58f51.png)


**Other changes**
Also replaced the `useSnapshotId` import in `useTotalLocked`. It now imports the hooks from the file instead of the store.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (This change updates documenantion)
- [ ] Release (This pull request refers to a new version release)
- [ ] Other (This change updates documentation)

## How Has This Been Tested?

Manual testing.

To test: go to a proposal page in any deployed guild, like:
http://localhost:3000/#/gnosis/0x3f842726188FcD932d43bcA291be28138228e6D9/proposal/0x00514250dbe1f619f4adcc6b90f47be899d5a36bee900d2754c2b4e1dd5ee7f5

The votes and quorum should be correct.

**Test Configuration**:

- Node version: 12.13.1
- OS: Linux

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
