### PR TITLE
Feat/type: added typings to useTotalLocked and useSnapshotId

### DIFF
--- a/apps/davi/src/stores/modules/SnapshotERC20Guild/fetchers/rpc/useTotalLocked.ts
+++ b/apps/davi/src/stores/modules/SnapshotERC20Guild/fetchers/rpc/useTotalLocked.ts
@@ -3,30 +3,26 @@ import { BigNumber } from 'ethers';
 import { useListenToLockAndWithdrawTokens } from '../../events/useListenToLockAndWithdrawTokens';
 import { SnapshotERC20Guild } from 'contracts/ts-files/SnapshotERC20Guild';
 import { useSnapshotId } from 'stores/modules/common/fetchers';
+import { FetcherHooksInterface } from 'stores/types';
 
-export const useTotalLocked = (
-  guildAddress: string,
-  proposalId?: `0x${string}`
-) => {
+type IUseTotalLocked = FetcherHooksInterface['useTotalLocked'];
+
+export const useTotalLocked: IUseTotalLocked = (guildAddress, proposalId?) => {
   const { data: snapshotId } = useSnapshotId({
     contractAddress: guildAddress,
     proposalId,
   });
 
-  const {
-    data: totalLockedResponse,
-    refetch: refetchGetTotalLocked,
-    ...totalLockedResponseRest
-  } = useContractRead({
-    address: guildAddress,
-    abi: SnapshotERC20Guild.abi,
-    functionName: 'getTotalLocked',
-  });
+  const { data: totalLockedResponse, refetch: refetchGetTotalLocked } =
+    useContractRead({
+      address: guildAddress,
+      abi: SnapshotERC20Guild.abi,
+      functionName: 'getTotalLocked',
+    });
 
   const {
     data: totalLockedAtProposalSnapshotResponse,
     refetch: refetchTotalLockedAt,
-    ...totalLockedAtProposalSnapshotResponseRest
   } = useContractRead({
     address: guildAddress,
     abi: SnapshotERC20Guild.abi,
@@ -44,12 +40,10 @@ export const useTotalLocked = (
         data: totalLockedAtProposalSnapshotResponse
           ? BigNumber.from(totalLockedAtProposalSnapshotResponse)
           : undefined,
-        ...totalLockedAtProposalSnapshotResponseRest,
       }
     : {
         data: totalLockedResponse
           ? BigNumber.from(totalLockedResponse)
           : undefined,
-        ...totalLockedResponseRest,
       };
 };

--- a/apps/davi/src/stores/modules/SnapshotRepGuild/fetchers/rpc/useTotalLocked.ts
+++ b/apps/davi/src/stores/modules/SnapshotRepGuild/fetchers/rpc/useTotalLocked.ts
@@ -5,11 +5,11 @@ import { ERC20SnapshotRep } from 'contracts/ts-files/ERC20SnapshotRep';
 import useGuildToken from 'Modules/Guilds/Hooks/useGuildToken';
 import { useListenToTokenTransfer } from '../../events/useListenToTokenTransfer';
 import { useSnapshotId } from 'stores/modules/common/fetchers';
+import { FetcherHooksInterface } from 'stores/types';
 
-export const useTotalLocked = (
-  guildAddress: string,
-  proposalId?: `0x${string}`
-) => {
+type IUseTotalLocked = FetcherHooksInterface['useTotalLocked'];
+
+export const useTotalLocked: IUseTotalLocked = (guildAddress, proposalId) => {
   const { data: guildTokenAddress } = useGuildToken(guildAddress);
 
   const { data: snapshotId } = useSnapshotId({
@@ -17,20 +17,16 @@ export const useTotalLocked = (
     proposalId,
   });
 
-  const {
-    data: totalLockedResponse,
-    refetch: refetchTotalLockedResponse,
-    ...totalLockedResponseRest
-  } = useContractRead({
-    address: guildAddress,
-    abi: BaseERC20Guild.abi,
-    functionName: 'getTotalLocked',
-  });
+  const { data: totalLockedResponse, refetch: refetchTotalLockedResponse } =
+    useContractRead({
+      address: guildAddress,
+      abi: BaseERC20Guild.abi,
+      functionName: 'getTotalLocked',
+    });
 
   const {
     data: totalSupplyAtSnapshotResponse,
     refetch: refetchTotalSupplyAtSnapshotResponse,
-    ...totalSupplyAtSnapshotResponseRest
   } = useContractRead({
     address: guildTokenAddress,
     abi: ERC20SnapshotRep.abi,
@@ -48,14 +44,10 @@ export const useTotalLocked = (
         data: totalSupplyAtSnapshotResponse
           ? BigNumber.from(totalSupplyAtSnapshotResponse)
           : undefined,
-        refetchTotalSupplyAtSnapshotResponse,
-        ...totalSupplyAtSnapshotResponseRest,
       }
     : {
         data: totalLockedResponse
           ? BigNumber.from(totalLockedResponse)
           : undefined,
-        refetchTotalLockedResponse,
-        ...totalLockedResponseRest,
       };
 };

--- a/apps/davi/src/stores/modules/SnapshotRepGuild/index.ts
+++ b/apps/davi/src/stores/modules/SnapshotRepGuild/index.ts
@@ -27,6 +27,7 @@ export const snapshotRepGuildImplementation: Readonly<FullGovernanceImplementati
       '0x5220f03f768c7f09437ccf760eb5307dc60f60e18c9c9ff9599a9ab3ad71d2a0',
       '0xb33418b664bfb6eba3ea37a77429d95daee4f0ab24f47ee63c4669340c4aae5a',
       '0x56735be1df2293bbbc687502a3673244d05fac86940394cb2222ea884f304daf',
+      '0xec75e00a4daa1f5d4636a962298f55e322161e54b292f04a928c91f4f5333aed',
       localConfig.bytecodeHash as `0x${string}`,
       localConfig.deployedBytecodeHash as `0x${string}`,
       prodConfig.deployedBytecodeHash as `0x${string}`,

--- a/apps/davi/src/stores/modules/common/fetchers/useSnapshotId.test.ts
+++ b/apps/davi/src/stores/modules/common/fetchers/useSnapshotId.test.ts
@@ -8,19 +8,15 @@ jest.mock('stores/modules/common/fetchers/useSnapshotId', () => ({
   __esModule: true,
   default: () => ({
     data: MOCK_SNAPSHOT_ID,
-    isError: false,
-    isLoading: false,
   }),
 }));
 
 describe('useSnapshotId', () => {
   it('should return proposal snapshot ID', () => {
-    const { data, isError, isLoading } = useSnapshotId({
+    const { data } = useSnapshotId({
       contractAddress: MOCK_CONTRACT_ADDRESS,
       proposalId: MOCK_PROPOSAL_ID,
     });
     expect(data).toMatchInlineSnapshot(`1`);
-    expect(isError).toBe(false);
-    expect(isLoading).toBe(false);
   });
 });

--- a/apps/davi/src/stores/modules/common/fetchers/useSnapshotId.ts
+++ b/apps/davi/src/stores/modules/common/fetchers/useSnapshotId.ts
@@ -3,16 +3,14 @@ import { BigNumber } from 'ethers';
 import { useContractEvent, useContractRead } from 'wagmi';
 import { SnapshotERC20Guild } from 'contracts/ts-files/SnapshotERC20Guild';
 import { useHookStoreProvider } from 'stores';
+import { FetcherHooksInterface } from 'stores/types';
 
-interface useSnapshotIdProps {
-  contractAddress: string;
-  proposalId: `0x${string}`;
-}
+type IUseSnapshotId = FetcherHooksInterface['useSnapshotId'];
 
-export const useSnapshotId = ({
+export const useSnapshotId: IUseSnapshotId = ({
   contractAddress,
   proposalId,
-}: useSnapshotIdProps) => {
+}) => {
   const {
     capabilities: { votingPowerTally },
   } = useHookStoreProvider();

--- a/apps/davi/src/stores/types.ts
+++ b/apps/davi/src/stores/types.ts
@@ -1,7 +1,5 @@
 import { BigNumber } from 'ethers';
 import { useProposal } from './modules/common/fetchers/useProposal';
-import { useSnapshotId } from './modules/common/fetchers/useSnapshotId';
-import { useTotalLocked } from './modules/SnapshotERC20Guild/fetchers/rpc/useTotalLocked';
 import { Option } from 'components/ActionsBuilder/types';
 
 interface GovernanceCapabilities {
@@ -23,11 +21,13 @@ export interface FetcherHooksInterface {
   useSnapshotId: (useSnapshotIdProps: {
     contractAddress: string;
     proposalId: `0x${string}`;
-  }) => ReturnType<typeof useSnapshotId>;
+  }) => { data: BigNumber };
   useTotalLocked: (
     daoId: string,
     proposalId?: `0x${string}`
-  ) => ReturnType<typeof useTotalLocked>;
+  ) => {
+    data: BigNumber;
+  };
   useIsProposalCreationAllowed: (
     daoId: string,
     userAddress: `0x${string}`


### PR DESCRIPTION
## Description

This PR replaces the `ReturnType` typings in the store for proper type definitions. Also removed unused returned parameters (like `isError` and `isLoading`).

The `useProposal` typings is intentionally left as is because adding types to it will require adding string literal types (`0x${string}`) everywhere in the application, and thus might be best suited for another PR.

Added a missing bytecode for SnapshotRepGuild store.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (This change updates documenantion)
- [ ] Release (This pull request refers to a new version release)
- [x] Other: added typings

## How Has This Been Tested?

This adds types and removes unused returned data.

The functionality of `useSnapshotId` and `useTotalLocked` should remain unchanged.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
