### PR TITLE
Fix: open links of proposal description in new tab

### DIFF
--- a/apps/davi/src/components/ProposalDescription/ProposalDescription.tsx
+++ b/apps/davi/src/components/ProposalDescription/ProposalDescription.tsx
@@ -21,7 +21,20 @@ export const ProposalDescription: React.FC<ProposalDescriptionProps> = ({
   return (
     <ProposalDescriptionWrapper>
       {metadata?.description ? (
-        <Markdown>{metadata.description}</Markdown>
+        <Markdown
+          options={{
+            overrides: {
+              a: {
+                props: {
+                  target: '_blank',
+                  rel: 'noopener noreferrer',
+                },
+              },
+            },
+          }}
+        >
+          {metadata.description}
+        </Markdown>
       ) : (
         <Loading loading text skeletonProps={{ width: '100%' }} />
       )}


### PR DESCRIPTION
## Description

Links in the body of the proposal now open in a new tab instead of the current page.

Fixes #39 

https://www.loom.com/share/d91edb4ef7534a60b38dd666ed4bae2c

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (This change updates documenantion)
- [ ] Release (This pull request refers to a new version release)
- [ ] Other (This change updates documentation)

## How Has This Been Tested?

Manual testing.

Go to a proposal with a link in the proposal body ([example](https://qa.projectdavi.eth.limo/#/gnosis/0xfd40F8ab40f21f99810E0A060BDc49d082Ce23D5/proposal/0xaf8873ce6a578f7d4f4e26d4ce6d08cbcefb9eaf7387067b589dffe8a7e7da96)) and click on a link. It should open a new tab.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
