### PR TITLE
Refactor getBlockExplorerUrl

### DIFF
--- a/apps/davi/src/components/ActionsBuilder/SupportedActions/GenericCall/GenericCallInfoLine.test.tsx
+++ b/apps/davi/src/components/ActionsBuilder/SupportedActions/GenericCall/GenericCallInfoLine.test.tsx
@@ -69,6 +69,10 @@ jest.mock('wagmi', () => ({
   },
 }));
 
+jest.mock('provider', () => ({
+  getBlockExplorerUrl: () => null,
+}));
+
 describe('GenericCallInfoLine', () => {
   it('Should match snapshot', () => {
     const { container } = render(

--- a/apps/davi/src/components/ActionsBuilder/SupportedActions/GenericCall/GenericCallParamsMatcher.test.tsx
+++ b/apps/davi/src/components/ActionsBuilder/SupportedActions/GenericCall/GenericCallParamsMatcher.test.tsx
@@ -36,6 +36,10 @@ jest.mock('wagmi', () => ({
   },
 }));
 
+jest.mock('provider', () => ({
+  getBlockExplorerUrl: () => null,
+}));
+
 describe('GenericCallParamsMatcher', () => {
   const paramDefaults: Omit<
     FunctionParamWithValue,

--- a/apps/davi/src/components/ActionsBuilder/SupportedActions/UpdateENSContent/UpdateENSContentSummary.test.tsx
+++ b/apps/davi/src/components/ActionsBuilder/SupportedActions/UpdateENSContent/UpdateENSContentSummary.test.tsx
@@ -45,6 +45,10 @@ jest.mock('wagmi', () => ({
   },
 }));
 
+jest.mock('provider', () => ({
+  getBlockExplorerUrl: () => null,
+}));
+
 const mockBigNumber = BigNumber.from(100000000);
 
 jest.mock('hooks/Guilds/erc20/useERC20Info', () => ({

--- a/apps/davi/src/components/ActionsBuilder/SupportedActions/UpdateENSContent/__snapshots__/UpdateENSContentSummary.test.tsx.snap
+++ b/apps/davi/src/components/ActionsBuilder/SupportedActions/UpdateENSContent/__snapshots__/UpdateENSContentSummary.test.tsx.snap
@@ -128,7 +128,6 @@ exports[`UpdateENSNameSummary Should match snapshot 1`] = `
       >
         <a
           class="c5"
-          href="https://etherscan.io/address/0x0000000000000000000000000000000000000000"
           rel="noopener"
           target="_blank"
         >
@@ -299,7 +298,6 @@ exports[`UpdateENSNameSummary Should match snapshot 1`] = `
         </span>
         <a
           class="c5"
-          href="https://etherscan.io/address/0x3f943f38b2fbe1ee5daf0516cecfe4e0f8734351"
           rel="noopener"
           target="_blank"
         >

--- a/apps/davi/src/components/ActionsBuilder/UndecodableCalls/UndecodableCallDetails.test.tsx
+++ b/apps/davi/src/components/ActionsBuilder/UndecodableCalls/UndecodableCallDetails.test.tsx
@@ -50,6 +50,10 @@ jest.mock('hooks/Guilds/tokens/useTokenList', () => ({
   }),
 }));
 
+jest.mock('provider', () => ({
+  getBlockExplorerUrl: () => null,
+}));
+
 describe('UndecodableCallDetails', () => {
   it('Should match snapshot', () => {
     const { container } = render(<UndecodableCallDetails call={callMock} />);

--- a/apps/davi/src/components/ActionsModal/ActionsModal.test.tsx
+++ b/apps/davi/src/components/ActionsModal/ActionsModal.test.tsx
@@ -46,6 +46,10 @@ jest.mock('wagmi', () => ({
   },
 }));
 
+jest.mock('provider', () => ({
+  getBlockExplorerUrl: () => null,
+}));
+
 describe('ActionsModal', () => {
   let props;
   beforeEach(() => {

--- a/apps/davi/src/components/DiscussionCard/DiscussionCard.test.tsx
+++ b/apps/davi/src/components/DiscussionCard/DiscussionCard.test.tsx
@@ -27,6 +27,10 @@ jest.mock('contexts/Guilds/orbis', () => ({
   }),
 }));
 
+jest.mock('provider', () => ({
+  getBlockExplorerUrl: () => null,
+}));
+
 describe('DiscussionCard', () => {
   it('should render with full parameters', async () => {
     const { container } = render(<DiscussionCard {...fullParameters} />);

--- a/apps/davi/src/components/GuildCard/GuildCard.test.tsx
+++ b/apps/davi/src/components/GuildCard/GuildCard.test.tsx
@@ -9,6 +9,10 @@ jest.mock('wagmi', () => ({
   }),
 }));
 
+jest.mock('provider', () => ({
+  getBlockExplorerUrl: () => null,
+}));
+
 describe('GuildCard', () => {
   it(`Should render with full parameters`, async () => {
     const { container } = render(<GuildCard {...fullParameters} />);

--- a/apps/davi/src/components/GuildSidebar/GuildSidebar.test.tsx
+++ b/apps/davi/src/components/GuildSidebar/GuildSidebar.test.tsx
@@ -16,6 +16,10 @@ jest.mock('wagmi', () => ({
   }),
 }));
 
+jest.mock('provider', () => ({
+  getBlockExplorerUrl: () => null,
+}));
+
 describe('GuildSidebar', () => {
   it(`Should render without data`, async () => {
     const { container } = render(<GuildSidebar />);

--- a/apps/davi/src/components/ProposalCard/ProposalCard.test.tsx
+++ b/apps/davi/src/components/ProposalCard/ProposalCard.test.tsx
@@ -53,6 +53,10 @@ jest.mock('wagmi', () => ({
   useNetwork: () => ({ chain: mockChain, chains: [mockChain] }),
 }));
 
+jest.mock('provider', () => ({
+  getBlockExplorerUrl: () => null,
+}));
+
 const validProps: ProposalCardProps = {
   proposal: proposalMock,
   ensAvatar: ensAvatarMock,

--- a/apps/davi/src/components/ProposalTypes/ProposalTypes.test.tsx
+++ b/apps/davi/src/components/ProposalTypes/ProposalTypes.test.tsx
@@ -7,6 +7,10 @@ jest.mock('wagmi', () => ({
   useNetwork: () => ({ chain: { id: mockChainId } }),
 }));
 
+jest.mock('provider', () => ({
+  getBlockExplorerUrl: () => null,
+}));
+
 describe('ProposalTypes', () => {
   const props = testProps;
 

--- a/apps/davi/src/components/ToastNotifications/TransactionToasts.tsx
+++ b/apps/davi/src/components/ToastNotifications/TransactionToasts.tsx
@@ -1,8 +1,8 @@
-import { chains } from 'provider';
 import React from 'react';
+import { Chain, useNetwork } from 'wagmi';
+import { getBlockExplorerUrl } from 'provider';
 import { NotificationDetail } from './NotificationDetail';
 import { NotificationHeading } from './NotificationHeading';
-import { getBlockchainLink } from 'utils';
 
 export const TransactionPending: React.FC<{ summary: string }> = ({
   summary,
@@ -13,15 +13,15 @@ export const TransactionPending: React.FC<{ summary: string }> = ({
 export const TransactionOutcome: React.FC<{
   summary: string;
   transactionHash: string;
-  chainId: number;
-}> = ({ summary, chainId, transactionHash }) => {
-  const networkName = chains.find(chain => chain.id === chainId).name;
+  chain: Chain;
+}> = ({ summary, transactionHash }) => {
+  const { chain } = useNetwork();
   return (
     <div>
       <NotificationHeading>{summary}</NotificationHeading>
       <NotificationDetail>
         <a
-          href={getBlockchainLink(transactionHash, networkName)}
+          href={getBlockExplorerUrl(chain, transactionHash, 'tx')}
           target="_blank"
           rel="noreferrer"
         >

--- a/apps/davi/src/components/Web3Modals/components/Transaction/Transaction.tsx
+++ b/apps/davi/src/components/Web3Modals/components/Transaction/Transaction.tsx
@@ -15,7 +15,7 @@ export const Transaction: React.FC<TransactionProps> = ({ transaction }) => {
   return (
     <TransactionContainer>
       <Link
-        href={getBlockExplorerUrl(chain, transaction.hash, 'address')}
+        href={getBlockExplorerUrl(chain, transaction.hash, 'tx')}
         target="_blank"
       >
         {transaction.summary} <FiArrowUpRight />

--- a/apps/davi/src/components/primitives/Links/BLockExplorerLink.test.tsx
+++ b/apps/davi/src/components/primitives/Links/BLockExplorerLink.test.tsx
@@ -2,6 +2,10 @@ import { mockBigNumber } from 'components/ActionsBuilder/SupportedActions/SetGui
 import { render } from 'utils/tests';
 import { BlockExplorerLink } from './BlockExplorerLink';
 
+jest.mock('provider', () => ({
+  getBlockExplorerUrl: () => null,
+}));
+
 jest.mock('wagmi', () => ({
   useNetwork: () => ({
     chain: {

--- a/apps/davi/src/components/primitives/Links/BlockExplorerLink.tsx
+++ b/apps/davi/src/components/primitives/Links/BlockExplorerLink.tsx
@@ -6,20 +6,11 @@ import { useTokenList } from 'hooks/Guilds/tokens/useTokenList';
 import { useMemo } from 'react';
 import { MAINNET_ID, shortenAddress } from 'utils';
 import { resolveUri } from 'utils/url';
-import { Chain, useNetwork } from 'wagmi';
+import { useNetwork } from 'wagmi';
 import { Flex } from '../Layout';
 import { ExternalLink } from './ExternalLink';
 import { BlockExplorerLinkProps } from './types';
-
-const getBlockExplorerUrl = (
-  chain: Chain,
-  address: string,
-  type: 'address' | 'tx'
-) => {
-  if (!chain || !chain?.blockExplorers?.default) return null;
-
-  return `${chain.blockExplorers.default.url}/${type}/${address}`;
-};
+import { getBlockExplorerUrl } from 'provider';
 
 export const BlockExplorerLink: React.FC<BlockExplorerLinkProps> = ({
   address,

--- a/apps/davi/src/contexts/Guilds/transactions.tsx
+++ b/apps/davi/src/contexts/Guilds/transactions.tsx
@@ -156,7 +156,7 @@ export const TransactionsProvider = ({ children }) => {
             render: (
               <TransactionOutcome
                 summary={transaction.summary}
-                chainId={chainId}
+                chain={chain}
                 transactionHash={transaction.hash}
               />
             ),
@@ -170,7 +170,7 @@ export const TransactionsProvider = ({ children }) => {
             render: (
               <TransactionOutcome
                 summary={transaction.summary}
-                chainId={chainId}
+                chain={chain}
                 transactionHash={transaction.hash}
               />
             ),
@@ -181,7 +181,7 @@ export const TransactionsProvider = ({ children }) => {
         }
       }
     });
-  }, [allTransactions, chainId]);
+  }, [allTransactions, chain]);
 
   // Trigger a new transaction request to the user wallet and track its progress
   const createTransaction = async (

--- a/apps/davi/src/utils/address.ts
+++ b/apps/davi/src/utils/address.ts
@@ -1,5 +1,4 @@
 import { ethers, utils } from 'ethers';
-import { NETWORK_EXPLORERS } from './index';
 
 const arbitrum = require('../configs/arbitrum/config.json');
 const arbitrumTestnet = require('../configs/arbitrumTestnet/config.json');
@@ -49,21 +48,6 @@ export function toAddressStub(address, size = 'default') {
       return address;
     default:
       return `${start}...${end}`;
-  }
-}
-
-export function getBlockchainLink(
-  address: string,
-  networkName: string,
-  type?: string
-) {
-  switch (type) {
-    case 'user':
-      return `${window.location.pathname}#/user/${address}`;
-    case 'address':
-      return `${NETWORK_EXPLORERS[networkName]}/address/${address}`;
-    default:
-      return `${NETWORK_EXPLORERS[networkName]}/tx/${address}`;
   }
 }
 


### PR DESCRIPTION
Small refactor: unified block explorer URL generation. Uses `getBlockExplorerUrl` exported by provider.

Also fixed bug where clicking a transaction in the transactions modal generated an address URL instead of a transaction hash URL.

All functionality remains the same.