### PR TITLE
feat: Update turbo config to fix build issue.

### DIFF
--- a/apps/dxdao-subgraph/package.json
+++ b/apps/dxdao-subgraph/package.json
@@ -31,7 +31,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-register": "^6.26.0",
     "js-yaml": "^4.1.0",
-    "dxdao-contracts": "*"
+    "dxdao-contracts": "workspace:*"
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,7 +473,7 @@ importers:
       '@typescript-eslint/parser': ^5.38.0
       babel-polyfill: ^6.26.0
       babel-register: ^6.26.0
-      dxdao-contracts: '*'
+      dxdao-contracts: workspace:*
       eslint: ^8.23.1
       eslint-config-prettier: ^8.5.0
       glob: ^8.0.3

--- a/turbo.json
+++ b/turbo.json
@@ -14,8 +14,11 @@
       "dependsOn": ["clean"],
       "outputs": ["artifacts/**"]
     },
+    "dxdao-contracts#setup": {
+      "outputs": ["types/**"]
+    },
     "dev-scripts#compile": {
-      "dependsOn": ["^dxdao-contracts#compile"]
+      "dependsOn": ["^dxdao-contracts#compile", "^dxdao-contracts#setup"]
     },
     "dev-scripts#dev": {
       "dependsOn": ["dev-scripts#compile"],


### PR DESCRIPTION
What went wrong:

We didn't specify the `dxdao-contracts/types` folder as a build output. When there was any code change in the contracts and Turbo hit a cache miss, the build was going through fine. But when it was using the build cache, the `types` folder wasn't there in the cache and the frontend build failed.