### PR TITLE
fix: time diff humanize test with dst

### DIFF
--- a/apps/davi/src/hooks/Guilds/time/useTimeDifferenceHumanized.test.ts
+++ b/apps/davi/src/hooks/Guilds/time/useTimeDifferenceHumanized.test.ts
@@ -3,8 +3,8 @@ import useTimeDifferenceHumanized from './useTimeDifferenceHumanized';
 
 describe('useTimeDifferenceHumanized', () => {
   it('should return humanized date for the diff between from and to dates', () => {
-    const toDate = moment('2022-05-09T08:00:00');
-    const fromDate = moment('2022-01-09T08:00:00');
+    const toDate = moment('2022-05-09T08:00:00+00:00');
+    const fromDate = moment('2022-01-09T08:00:00+00:00');
 
     const humanizedDate = useTimeDifferenceHumanized(toDate, fromDate);
     expect(humanizedDate).toBe('4 duration.months_other');


### PR DESCRIPTION
The test for the time difference humanizing custom hook (`useTimeDifferenceHumanized.ts`) fails with daylight saving time based on the location user accessing.

Therefore, This fix incorporates the GMT timezone to avoid the moment library changing the time zones.