### PR TITLE
Fix: page crashes when switching networks

### DIFF
--- a/apps/davi/src/stores/index.tsx
+++ b/apps/davi/src/stores/index.tsx
@@ -155,7 +155,13 @@ export const HookStoreProvider: React.FC<
   }, [governanceType, dataSource, chain]);
 
   if (!daoId) return <>{children}</>;
-  if (!governanceType || !governanceType?.dataSource) return <LoadingPage />;
+  if (
+    !governanceType ||
+    !governanceType?.dataSource ||
+    shouldSwitchDataSource
+  ) {
+    return <LoadingPage />;
+  }
 
   return (
     <HookStoreContext.Provider value={{ ...governanceType, isLoading, daoId }}>


### PR DESCRIPTION
Fixed bug causing the page to crash to a white screen while switching networks. Most specifically, happened when switching networks and data sources.

It now checks wether `shouldSwitchDataSource`. If it's true, it renders a loading page.

How to test:
1. Go to any page in a network that uses the primary data source (like localhost).
2. Switch the network to one that uses the secondary data source (like Gnosis).
3. The page shouldn't crash

