### PR TITLE
fix: Proposal not found when loading proposal via subgraph

### DIFF
--- a/apps/davi/src/Modules/Guilds/pages/Proposal/Proposal.tsx
+++ b/apps/davi/src/Modules/Guilds/pages/Proposal/Proposal.tsx
@@ -87,7 +87,7 @@ const ProposalPage: React.FC = () => {
     return <></>;
   } else {
     if (!isGuildAvailabilityLoading) {
-      if (!proposalIds?.includes(proposalId)) {
+      if (proposalIds && proposalIds.includes(proposalId) === false) {
         return (
           <Result
             state={ResultState.ERROR}
@@ -121,7 +121,6 @@ const ProposalPage: React.FC = () => {
         );
       }
     }
-
     return (
       <PageContainer>
         <PageContent>

--- a/apps/davi/src/components/ActionsBuilder/ConfirmRemoveActionModal/ConfirmRemoveActionModal.tsx
+++ b/apps/davi/src/components/ActionsBuilder/ConfirmRemoveActionModal/ConfirmRemoveActionModal.tsx
@@ -34,7 +34,7 @@ const ConfirmRemoveActionModal: React.FC<ConfirmRemoveActionModalProps> = ({
       <Container>
         <TextContainer>
           <Title>
-            {t('actionBuilder.action.areYuoSureYouWantToRemoveAction')}
+            {t('actionBuilder.action.areYouSureYouWantToRemoveAction')}
           </Title>
           <InfoItem>
             {t('actionBuilder.action.theRemovalCannotBeReverted')}
@@ -42,9 +42,7 @@ const ConfirmRemoveActionModal: React.FC<ConfirmRemoveActionModalProps> = ({
         </TextContainer>
 
         <ActionWrapper>
-          <CancelButton onClick={onDismiss}>
-            {t('actionBuilder.modal.cancel')}
-          </CancelButton>
+          <CancelButton onClick={onDismiss}>{t('modals.cancel')}</CancelButton>
           <ConfirmButton onClick={onConfirm}>
             {t('actionBuilder.action.removeAction')}
           </ConfirmButton>

--- a/apps/davi/src/components/ActionsBuilder/OptionsList/SimulationModal/SimulationModal.tsx
+++ b/apps/davi/src/components/ActionsBuilder/OptionsList/SimulationModal/SimulationModal.tsx
@@ -42,7 +42,7 @@ export const SimulationModal: React.FC<SimulationModalProps> = ({
         <StatusWrapper>
           <SimulationStatusWrapper status={status} />
           <Flex direction="row">
-            <Muted>{t('actionBuilder.poweredBy')}</Muted>{' '}
+            <Muted>{t('actionBuilder.simulations.poweredBy')}</Muted>{' '}
             <TenderlyLogo src={tenderlyLogo} />
           </Flex>
         </StatusWrapper>


### PR DESCRIPTION
Closes: 
https://github.com/DXgovernance/davi-monorepo/issues/205
Fix: 
 - some missing translation keys
 - Fixed the issue of the proposal showing an error page a split second after loading (will now only show the error page if the `proposalIds` array exists but not the specific proposalId.