### PR TITLE
Fix: Round up percentages

### DIFF
--- a/apps/davi/src/Modules/Guilds/Hooks/useVotingPowerPercent.ts
+++ b/apps/davi/src/Modules/Guilds/Hooks/useVotingPowerPercent.ts
@@ -5,11 +5,11 @@ import { getBigNumberPercentage } from 'utils/bnPercentage';
 export default function useVotingPowerPercent(
   userVotingPower: BigNumber,
   totalVotingPower: BigNumber,
-  precision: number = 2
+  decimals: number = 2
 ) {
   const votingPowerPercent = useMemo(() => {
-    return getBigNumberPercentage(userVotingPower, totalVotingPower, precision);
-  }, [totalVotingPower, userVotingPower, precision]);
+    return getBigNumberPercentage(userVotingPower, totalVotingPower, decimals);
+  }, [totalVotingPower, userVotingPower, decimals]);
 
   return votingPowerPercent;
 }

--- a/apps/davi/src/components/ProposalVoteCard/components/UserVote/UserVote.tsx
+++ b/apps/davi/src/components/ProposalVoteCard/components/UserVote/UserVote.tsx
@@ -14,8 +14,7 @@ const UserVote: React.FC<UserVoteProps> = ({
   const { t } = useTranslation();
   const votingPowerPercent = useVotingPowerPercent(
     userVote?.votingPower,
-    voteData?.totalLocked,
-    2
+    voteData?.totalLocked
   );
 
   const voting = `${formatUnits(userVote?.votingPower || 0)} ${

--- a/apps/davi/src/components/ProposalVoteCard/components/VoteResults/VoteResults.tsx
+++ b/apps/davi/src/components/ProposalVoteCard/components/VoteResults/VoteResults.tsx
@@ -29,8 +29,7 @@ const VoteResultRow: React.FC<ResultRowProps> = ({
 
   const votingPowerPercent = useVotingPowerPercent(
     voteData?.options?.[optionKey],
-    voteData?.totalLocked,
-    2
+    voteData?.totalLocked
   );
   const label = getGuildOptionLabel({
     metadata: proposalMetadata,

--- a/apps/davi/src/hooks/Guilds/useVoteSummary.ts
+++ b/apps/davi/src/hooks/Guilds/useVoteSummary.ts
@@ -22,7 +22,7 @@ export default function useVoteSummary(
       const newVotes = [];
       for (var i = 0; i <= totalVotes?.length - 1; i++) {
         if (totalVotes[i]?.gt(0)) {
-          newVotes.push(getBigNumberPercentage(totalVotes[i], totalLocked, 2));
+          newVotes.push(getBigNumberPercentage(totalVotes[i], totalLocked));
         } else {
           newVotes.push(0);
         }

--- a/apps/davi/src/stores/modules/guilds/common/fetchers/rpc/useProposalCalls/useProposalCalls.ts
+++ b/apps/davi/src/stores/modules/guilds/common/fetchers/rpc/useProposalCalls/useProposalCalls.ts
@@ -147,8 +147,7 @@ export const useProposalCalls: IUseProposalCalls = (daoId, proposal) => {
             totalVotes: votingResults?.options[index],
             votePercentage: getBigNumberPercentage(
               votingResults?.options[index],
-              votingResults?.totalLocked,
-              2
+              votingResults?.totalLocked
             ),
           };
         })

--- a/apps/davi/src/stores/modules/guilds/common/fetchers/subgraph/useGetVotes/index.ts
+++ b/apps/davi/src/stores/modules/guilds/common/fetchers/subgraph/useGetVotes/index.ts
@@ -45,8 +45,7 @@ export const useGetVotes: IUseGetVotes = (guildId, proposal) => {
         optionLabel,
         votingPower: getBigNumberPercentage(
           BigNumber.from(vote?.votingPower),
-          totalLocked,
-          2
+          totalLocked
         ),
       };
     });

--- a/apps/davi/src/stores/modules/guilds/common/fetchers/subgraph/useProposal/index.ts
+++ b/apps/davi/src/stores/modules/guilds/common/fetchers/subgraph/useProposal/index.ts
@@ -80,8 +80,7 @@ export const useProposal: IUseProposal = (daoId, proposalId) => {
         optionLabel,
         votingPower: getBigNumberPercentage(
           BigNumber.from(vote?.votingPower),
-          totalLocked,
-          2
+          totalLocked
         ),
       };
     });

--- a/apps/davi/src/utils/bnPercentage.test.ts
+++ b/apps/davi/src/utils/bnPercentage.test.ts
@@ -1,0 +1,299 @@
+import { BigNumber } from 'ethers';
+import { getBigNumberPercentage } from './bnPercentage';
+
+describe('getBigNumberPercentage', () => {
+  test('standard precision', () => {
+    const result1 = getBigNumberPercentage(
+      BigNumber.from('46681218000000000000'),
+      BigNumber.from('116703045000000000002')
+    );
+    // 0.39999999999999999999
+    expect(result1).toBe(40);
+
+    const result2 = getBigNumberPercentage(
+      BigNumber.from('38348164999999999932'),
+      BigNumber.from('116703045000000000002')
+    );
+    // 0.32859609618583645295
+    expect(result2).toBe(32.86);
+
+    const result3 = getBigNumberPercentage(
+      BigNumber.from('50000000000000000000'),
+      BigNumber.from('100000000000000000000')
+    );
+    // 0.5
+    expect(result3).toBe(50);
+
+    const result4 = getBigNumberPercentage(
+      BigNumber.from('38748164999999999932'),
+      BigNumber.from('116703045000000000002')
+    );
+    // 0.33202359887010660202
+    expect(result4).toBe(33.2);
+
+    const zero = getBigNumberPercentage(
+      BigNumber.from('0'),
+      BigNumber.from('0')
+    );
+    expect(zero).toBe(0);
+
+    const result5 = getBigNumberPercentage(
+      BigNumber.from('52110000000000000000'),
+      BigNumber.from('100000000000000000000')
+    );
+    // 0.5211
+    expect(result5).toBe(52.11);
+  });
+
+  test('zero decimals precision', () => {
+    const result1 = getBigNumberPercentage(
+      BigNumber.from('46681218000000000000'),
+      BigNumber.from('116703045000000000002'),
+      0
+    );
+    // 0.39999999999999999999
+    expect(result1).toBe(40);
+
+    const result2 = getBigNumberPercentage(
+      BigNumber.from('38348164999999999932'),
+      BigNumber.from('116703045000000000002'),
+      0
+    );
+    // 0.32859609618583645295
+    expect(result2).toBe(33);
+
+    const result3 = getBigNumberPercentage(
+      BigNumber.from('50000000000000000000'),
+      BigNumber.from('100000000000000000000'),
+      0
+    );
+    // 0.5
+    expect(result3).toBe(50);
+
+    const result4 = getBigNumberPercentage(
+      BigNumber.from('38748164999999999932'),
+      BigNumber.from('116703045000000000002'),
+      0
+    );
+    // 0.33202359887010660202
+    expect(result4).toBe(33);
+
+    const result5 = getBigNumberPercentage(
+      BigNumber.from('52110000000000000000'),
+      BigNumber.from('100000000000000000000'),
+      0
+    );
+    // 0.5211
+    expect(result5).toBe(52);
+  });
+
+  test('one decimal precision', () => {
+    const result1 = getBigNumberPercentage(
+      BigNumber.from('46681218000000000000'),
+      BigNumber.from('116703045000000000002'),
+      1
+    );
+    // 0.39999999999999999999
+    expect(result1).toBe(40);
+
+    const result2 = getBigNumberPercentage(
+      BigNumber.from('38348164999999999932'),
+      BigNumber.from('116703045000000000002'),
+      1
+    );
+    // 0.32859609618583645295
+    expect(result2).toBe(32.9);
+
+    const result3 = getBigNumberPercentage(
+      BigNumber.from('50000000000000000000'),
+      BigNumber.from('100000000000000000000'),
+      1
+    );
+    // 0.5
+    expect(result3).toBe(50);
+
+    const result4 = getBigNumberPercentage(
+      BigNumber.from('38748164999999999932'),
+      BigNumber.from('116703045000000000002'),
+      1
+    );
+    // 0.33202359887010660202
+    expect(result4).toBe(33.2);
+
+    const result5 = getBigNumberPercentage(
+      BigNumber.from('52110000000000000000'),
+      BigNumber.from('100000000000000000000'),
+      1
+    );
+    // 0.5211
+    expect(result5).toBe(52.1);
+  });
+
+  test('two decimals precision', () => {
+    const result1 = getBigNumberPercentage(
+      BigNumber.from('46681218000000000000'),
+      BigNumber.from('116703045000000000002'),
+      2
+    );
+    // 0.39999999999999999999
+    expect(result1).toBe(40);
+
+    const result2 = getBigNumberPercentage(
+      BigNumber.from('38348164999999999932'),
+      BigNumber.from('116703045000000000002'),
+      2
+    );
+    // 0.32859609618583645295
+    expect(result2).toBe(32.86);
+
+    const result3 = getBigNumberPercentage(
+      BigNumber.from('50000000000000000000'),
+      BigNumber.from('100000000000000000000'),
+      2
+    );
+    // 0.5
+    expect(result3).toBe(50);
+
+    const result4 = getBigNumberPercentage(
+      BigNumber.from('38748164999999999932'),
+      BigNumber.from('116703045000000000002'),
+      2
+    );
+    // 0.33202359887010660202
+    expect(result4).toBe(33.2);
+
+    const result5 = getBigNumberPercentage(
+      BigNumber.from('52110000000000000000'),
+      BigNumber.from('100000000000000000000'),
+      2
+    );
+    // 0.5211
+    expect(result5).toBe(52.11);
+  });
+
+  test('three decimals precision', () => {
+    const result1 = getBigNumberPercentage(
+      BigNumber.from('46681218000000000000'),
+      BigNumber.from('116703045000000000002'),
+      3
+    );
+    // 0.39999999999999999999
+    expect(result1).toBe(40);
+
+    const result2 = getBigNumberPercentage(
+      BigNumber.from('38348164999999999932'),
+      BigNumber.from('116703045000000000002'),
+      3
+    );
+    // 0.32859609618583645295
+    expect(result2).toBe(32.86);
+
+    const result3 = getBigNumberPercentage(
+      BigNumber.from('50000000000000000000'),
+      BigNumber.from('100000000000000000000'),
+      3
+    );
+    // 0.5
+    expect(result3).toBe(50);
+
+    const result4 = getBigNumberPercentage(
+      BigNumber.from('38748164999999999932'),
+      BigNumber.from('116703045000000000002'),
+      3
+    );
+    // 0.33202359887010660202
+    expect(result4).toBe(33.202);
+
+    const result5 = getBigNumberPercentage(
+      BigNumber.from('52110000000000000000'),
+      BigNumber.from('100000000000000000000'),
+      3
+    );
+    // 0.5211
+    expect(result5).toBe(52.11);
+  });
+
+  test('four decimals precision', () => {
+    const result1 = getBigNumberPercentage(
+      BigNumber.from('46681218000000000000'),
+      BigNumber.from('116703045000000000002'),
+      4
+    );
+    // 0.39999999999999999999
+    expect(result1).toBe(40);
+
+    const result2 = getBigNumberPercentage(
+      BigNumber.from('38348164999999999932'),
+      BigNumber.from('116703045000000000002'),
+      4
+    );
+    // 0.32859609618583645295
+    expect(result2).toBe(32.8596);
+
+    const result3 = getBigNumberPercentage(
+      BigNumber.from('50000000000000000000'),
+      BigNumber.from('100000000000000000000'),
+      4
+    );
+    // 0.5
+    expect(result3).toBe(50);
+
+    const result4 = getBigNumberPercentage(
+      BigNumber.from('38748164999999999932'),
+      BigNumber.from('116703045000000000002'),
+      4
+    );
+    // 0.33202359887010660202
+    expect(result4).toBe(33.2024);
+
+    const result5 = getBigNumberPercentage(
+      BigNumber.from('52110000000000000000'),
+      BigNumber.from('100000000000000000000'),
+      4
+    );
+    // 0.5211
+    expect(result5).toBe(52.11);
+  });
+
+  test('five decimals precision', () => {
+    const result1 = getBigNumberPercentage(
+      BigNumber.from('46681218000000000000'),
+      BigNumber.from('116703045000000000002'),
+      5
+    );
+    // 0.39999999999999999999
+    expect(result1).toBe(40);
+
+    const result2 = getBigNumberPercentage(
+      BigNumber.from('38348164999999999932'),
+      BigNumber.from('116703045000000000002'),
+      5
+    );
+    // 0.32859609618583645295
+    expect(result2).toBe(32.85961);
+
+    const result3 = getBigNumberPercentage(
+      BigNumber.from('50000000000000000000'),
+      BigNumber.from('100000000000000000000'),
+      5
+    );
+    // 0.5
+    expect(result3).toBe(50);
+
+    const result4 = getBigNumberPercentage(
+      BigNumber.from('38748164999999999932'),
+      BigNumber.from('116703045000000000002'),
+      5
+    );
+    // 0.33202359887010660202
+    expect(result4).toBe(33.20236);
+
+    const result5 = getBigNumberPercentage(
+      BigNumber.from('52110000000000000000'),
+      BigNumber.from('100000000000000000000'),
+      5
+    );
+    // 0.5211
+    expect(result5).toBe(52.11);
+  });
+});

--- a/apps/davi/src/utils/bnPercentage.ts
+++ b/apps/davi/src/utils/bnPercentage.ts
@@ -1,15 +1,43 @@
 import { BigNumber } from 'ethers';
 
+const truncateNumber = (number: number, decimals: number): number => {
+  if (Number.isInteger(number)) return number;
+
+  const stringResult = number.toString();
+  const dotPosition = stringResult.indexOf('.');
+
+  return Number(stringResult.slice(0, dotPosition + decimals + 1));
+};
+
+const getAmountOfDecimalPlaces = (number: number): number => {
+  if (Number.isInteger(number)) return 0;
+  const numberString = number.toString();
+  const dotPosition = numberString.indexOf('.');
+  const numberOfDecimals = numberString.length - dotPosition - 1;
+  return numberOfDecimals;
+};
+
 // Used to calculate percentages of big numbers due to decimal limitation for things like voting power
 export function getBigNumberPercentage(
   amount: BigNumber,
   totalAmount: BigNumber,
-  precision: number = 2
+  decimals: number = 2
 ) {
   if (!amount || !totalAmount) return null;
-
   if (totalAmount.isZero()) return 0;
 
-  const percent = amount.mul(100).mul(Math.pow(10, precision)).div(totalAmount);
-  return Math.round(percent.toNumber()) / Math.pow(10, precision);
+  const percent = amount
+    .mul(100)
+    .mul(Math.pow(10, decimals + 1))
+    .div(totalAmount);
+
+  let result = Math.round(percent.toNumber()) / Math.pow(10, decimals + 1);
+
+  const numberOfDecimals = getAmountOfDecimalPlaces(result);
+  if (numberOfDecimals < decimals + 1) return result;
+
+  const lastDigit = parseInt(result.toString().slice(-1));
+  if (lastDigit >= 5) result += 1 / Math.pow(10, decimals);
+
+  return truncateNumber(result, decimals);
 }


### PR DESCRIPTION
## Description

- Refactored `getBigNumberPercentage` to round and truncate returned percentages based on the `decimals` parameter.
- Fixes some instances of a percentage returning 39.99 and returns 40 instead.
- Fixes some instances of decimal numbers returning a lot of decimals, breaking the UI.

Fixes #154 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (This change updates documenantion)
- [ ] Release (This pull request refers to a new version release)
- [ ] Other (This change updates documentation)

## How Has This Been Tested?

Made unit tests for various numbers and tests for up to 5 decimal places precision. 

Most of the places we use the function are using 2 decimals, so each time a percentage gets shown in the UI, should have only 2 decimal places.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
