### PR TITLE
Fix: Mint percentages are capped at 2 decimals

### DIFF
--- a/apps/davi/src/components/ActionsBuilder/SupportedActions/RepMint/RepMintInfoLine.tsx
+++ b/apps/davi/src/components/ActionsBuilder/SupportedActions/RepMint/RepMintInfoLine.tsx
@@ -5,11 +5,11 @@ import { MAINNET_ID, shortenAddress } from 'utils';
 import { ActionViewProps } from '..';
 import { Segment } from '../common/infoLine';
 import { ReactComponent as Mint } from 'assets/images/mint.svg';
-import useBigNumberToNumber from 'hooks/Guilds/conversions/useBigNumberToNumber';
 import { useTotalSupply } from 'Modules/Guilds/Hooks/useTotalSupply';
 import { useTokenData } from 'Modules/Guilds/Hooks/useTokenData';
 import { useTranslation } from 'react-i18next';
 import { StyledMintIcon } from './styles';
+import { getBigNumberPercentage } from 'utils/bnPercentage';
 
 const RepMintInfoLine: React.FC<ActionViewProps> = ({
   decodedCall,
@@ -21,12 +21,12 @@ const RepMintInfoLine: React.FC<ActionViewProps> = ({
   const { data } = useTotalSupply({ decodedCall });
   const { tokenData } = useTokenData();
 
-  const totalSupply = useBigNumberToNumber(tokenData?.totalSupply, 18);
-
   const { ensName, imageUrl } = useENSAvatar(data?.toAddress, MAINNET_ID);
 
-  const roundedRepAmount = useBigNumberToNumber(data?.amount, 16, 3);
-  const roundedRepPercent = roundedRepAmount / totalSupply;
+  const roundedRepPercent = getBigNumberPercentage(
+    data?.amount,
+    tokenData?.totalSupply
+  );
 
   return (
     <>

--- a/apps/davi/src/components/ActionsBuilder/SupportedActions/RepMint/RepMintSummary.tsx
+++ b/apps/davi/src/components/ActionsBuilder/SupportedActions/RepMint/RepMintSummary.tsx
@@ -5,11 +5,11 @@ import { MAINNET_ID, shortenAddress } from 'utils';
 import { ActionViewProps } from '..';
 import { Segment } from '../common/infoLine';
 import { ReactComponent as Mint } from 'assets/images/mint.svg';
-import useBigNumberToNumber from 'hooks/Guilds/conversions/useBigNumberToNumber';
 import { useTotalSupply } from 'Modules/Guilds/Hooks//useTotalSupply';
 import { useTokenData } from 'Modules/Guilds/Hooks/useTokenData';
 import { useTranslation } from 'react-i18next';
 import { StyledMintIcon } from './styles';
+import { getBigNumberPercentage } from 'utils/bnPercentage';
 
 const RepMintInfoLine: React.FC<ActionViewProps> = ({ decodedCall }) => {
   const { t } = useTranslation();
@@ -17,12 +17,12 @@ const RepMintInfoLine: React.FC<ActionViewProps> = ({ decodedCall }) => {
   const { data } = useTotalSupply({ decodedCall });
   const { tokenData } = useTokenData();
 
-  const totalSupply = useBigNumberToNumber(tokenData?.totalSupply, 18);
-
   const { ensName, imageUrl } = useENSAvatar(data?.toAddress, MAINNET_ID);
 
-  const roundedRepAmount = useBigNumberToNumber(data?.amount, 16, 3);
-  const roundedRepPercent = roundedRepAmount / totalSupply;
+  const roundedRepPercent = getBigNumberPercentage(
+    data?.amount,
+    tokenData?.totalSupply
+  );
 
   return (
     <>

--- a/apps/davi/src/components/ActionsBuilder/SupportedActions/RepMint/__snapshots__/RepMintInfoLine.test.tsx.snap
+++ b/apps/davi/src/components/ActionsBuilder/SupportedActions/RepMint/__snapshots__/RepMintInfoLine.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`RepMintInfoLine Should match snapshot 1`] = `
   >
     actionBuilder.repMint.mint
      
-    NaN
+    0.01
      %
   </span>
   <span
@@ -167,7 +167,7 @@ exports[`RepMintInfoLine Should match snapshot in compact mode 1`] = `
     class="c0"
   >
      
-    NaN
+    0.01
      %
   </span>
   <span
@@ -275,7 +275,7 @@ exports[`RepMintInfoLine Should match snapshot with default values 1`] = `
   >
     actionBuilder.repMint.mint
      
-    NaN
+    0
      %
   </span>
   <span
@@ -382,7 +382,7 @@ exports[`RepMintInfoLine Should match snapshot with default values in compact mo
     class="c0"
   >
      
-    NaN
+    0
      %
   </span>
   <span
@@ -490,7 +490,6 @@ exports[`RepMintInfoLine Should match snapshot without data 1`] = `
   >
     actionBuilder.repMint.mint
      
-    NaN
      %
   </span>
   <span
@@ -597,7 +596,6 @@ exports[`RepMintInfoLine Should match snapshot without data in compact mode 1`] 
     class="c0"
   >
      
-    NaN
      %
   </span>
   <span

--- a/apps/davi/src/components/ActionsBuilder/SupportedActions/RepMint/__snapshots__/RepMintSummary.test.tsx.snap
+++ b/apps/davi/src/components/ActionsBuilder/SupportedActions/RepMint/__snapshots__/RepMintSummary.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`RepMintSummary Should match snapshot 1`] = `
   >
     actionBuilder.repMint.mint
      
-    NaN
+    0.01
      %
   </span>
   <span
@@ -168,7 +168,7 @@ exports[`RepMintSummary Should match snapshot in compact mode 1`] = `
   >
     actionBuilder.repMint.mint
      
-    NaN
+    0.01
      %
   </span>
   <span
@@ -276,7 +276,7 @@ exports[`RepMintSummary Should match snapshot with default values 1`] = `
   >
     actionBuilder.repMint.mint
      
-    NaN
+    0
      %
   </span>
   <span
@@ -384,7 +384,7 @@ exports[`RepMintSummary Should match snapshot with default values in compact mod
   >
     actionBuilder.repMint.mint
      
-    NaN
+    0
      %
   </span>
   <span
@@ -492,7 +492,6 @@ exports[`RepMintSummary Should match snapshot without data 1`] = `
   >
     actionBuilder.repMint.mint
      
-    NaN
      %
   </span>
   <span
@@ -600,7 +599,6 @@ exports[`RepMintSummary Should match snapshot without data in compact mode 1`] =
   >
     actionBuilder.repMint.mint
      
-    NaN
      %
   </span>
   <span


### PR DESCRIPTION
Mint percentages in info line and summary are now rounded and capped at 2 decimals.

Previous mint percentages:
![image](https://user-images.githubusercontent.com/75996796/221935363-be2d005a-8247-421f-9b5d-960919619b18.png)


Current mint percentages:
![Screenshot from 2023-02-28 14-32-55](https://user-images.githubusercontent.com/75996796/221935054-508413fd-6f09-417d-94d9-e9397ecb2a54.png)
