### PR TITLE
Fix: page crash when trying to decode rep mint

### DIFF
--- a/apps/davi/src/Modules/Guilds/Hooks/useTotalSupply.ts
+++ b/apps/davi/src/Modules/Guilds/Hooks/useTotalSupply.ts
@@ -1,6 +1,6 @@
-import { DecodedCall } from 'components/ActionsBuilder/types';
 import { BigNumber } from 'ethers';
 import { useMemo } from 'react';
+import { DecodedCall } from 'components/ActionsBuilder/types';
 
 interface IUseTotalSupply {
   decodedCall: DecodedCall;

--- a/apps/davi/src/Modules/Guilds/Hooks/useTotalSupply.ts
+++ b/apps/davi/src/Modules/Guilds/Hooks/useTotalSupply.ts
@@ -1,16 +1,21 @@
+import { DecodedCall } from 'components/ActionsBuilder/types';
 import { BigNumber } from 'ethers';
 import { useMemo } from 'react';
+
+interface IUseTotalSupply {
+  decodedCall: DecodedCall;
+}
 
 interface RepMintState {
   toAddress: string;
   amount: BigNumber;
 }
 
-export const useTotalSupply = ({ decodedCall }) => {
+export const useTotalSupply = ({ decodedCall }: IUseTotalSupply) => {
   const parsedData = useMemo<RepMintState>(() => {
     if (!decodedCall) return null;
     return {
-      toAddress: decodedCall.args.to,
+      toAddress: decodedCall.args.account,
       amount: decodedCall.args.amount,
     };
   }, [decodedCall]);

--- a/apps/davi/src/utils/address.test.ts
+++ b/apps/davi/src/utils/address.test.ts
@@ -1,0 +1,28 @@
+import { shortenAddress } from './address';
+import { ANY_ADDRESS } from './constants';
+
+const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+describe('shortenAddress', () => {
+  test('should return a shorten address if everything is correct (default digits)', () => {
+    const result = shortenAddress(ANY_ADDRESS);
+    expect(result).toBe('0xaAaA...aaAa');
+  });
+
+  test('should return a shorten address if everything is correct (2 digits)', () => {
+    const result = shortenAddress(ANY_ADDRESS, 2);
+    expect(result).toBe('0xaA...Aa');
+  });
+
+  test('should return null and log error if address is undefined', () => {
+    const result = shortenAddress(undefined);
+    expect(result).toBeNull();
+    expect(consoleError).toBeCalled();
+  });
+
+  test('should return null and log error if parameter is not an address', () => {
+    const result = shortenAddress('0xNotAnAddress');
+    expect(result).toBeNull();
+    expect(consoleError).toBeCalled();
+  });
+});

--- a/apps/davi/src/utils/address.ts
+++ b/apps/davi/src/utils/address.ts
@@ -1,4 +1,5 @@
 import { ethers, utils } from 'ethers';
+import i18next from 'i18next';
 
 const arbitrum = require('../configs/arbitrum/config.json');
 const arbitrumTestnet = require('../configs/arbitrumTestnet/config.json');
@@ -17,8 +18,9 @@ const appConfig: AppConfig = {
 };
 
 export function shortenAddress(address: string, digits = 4) {
-  if (!isAddress(address)) {
-    throw Error(`Invalid 'address' parameter '${address}'.`);
+  if (!address || !isAddress(address)) {
+    console.error(`${i18next.t('inputValidation.invalidAddress')}: ${address}`);
+    return null;
   }
   return `${address.substring(0, digits + 2)}...${address.substring(
     42 - digits


### PR DESCRIPTION
# Description

Fixes bug causing a crash when trying to decode a rep mint action.

Closes #256 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added unit test for the `shortenAddress` function.

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any UI changes have been tested and made responsive for mobile views
