### PR TITLE
Fix: subsequent votes not updating voting power

### DIFF
--- a/apps/davi/src/stores/modules/guilds/common/fetchers/subgraph/useGetMemberList/query.graphql
+++ b/apps/davi/src/stores/modules/guilds/common/fetchers/subgraph/useGetMemberList/query.graphql
@@ -1,6 +1,6 @@
 query getMemberList($id: ID!) {
   guild(id: $id) {
-    members {
+    members(where: { tokensLocked_gt: "0" }) {
       id
       address
       tokensLocked

--- a/apps/guilds-subgraph/src/mappings/BaseERC20Guild/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/BaseERC20Guild/mapping.ts
@@ -123,8 +123,8 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
       }
 
       option.proposalId = proposalId;
-      option.actions = [];
       option.voteAmount = new BigInt(0);
+      option.save();
 
       // Skip Option zero and return actions []
       if (i > 0) {
@@ -134,20 +134,13 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
           action.optionId = optionId;
           let actionIndex = actionsPerOption * (i - 1) + j;
 
-          if (option.actions) {
-            action.data = data[actionIndex];
-            action.from = address.toHexString();
-            action.to = to[actionIndex];
-            action.value = proposalData.value[actionIndex];
-          }
-          let actionsCopy = option.actions;
-          actionsCopy!.push(actionId);
-          option.actions = actionsCopy;
+          action.data = data[actionIndex];
+          action.from = address.toHexString();
+          action.to = to[actionIndex];
+          action.value = proposalData.value[actionIndex];
           action.save();
         }
       }
-
-      option.save();
     }
   }
 

--- a/apps/guilds-subgraph/src/mappings/BaseERC20Guild/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/BaseERC20Guild/mapping.ts
@@ -149,14 +149,6 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
 
       option.save();
     }
-
-    let guild = Guild.load(address.toHexString());
-    if (guild) {
-      let proposalsCopy = guild.proposals;
-      proposalsCopy!.push(proposalId);
-      guild.proposals = proposalsCopy;
-      guild.save();
-    }
   }
 
   // executed

--- a/apps/guilds-subgraph/src/mappings/BaseERC20Guild/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/BaseERC20Guild/mapping.ts
@@ -229,12 +229,8 @@ export function handleTokenLocking(event: TokensLocked): void {
 
   if (!member) {
     member = new Member(memberId);
+    member.guildId = guildAddress.toHexString();
     member.address = event.params.voter.toHexString();
-
-    let guildMembersClone = guild.members;
-    guildMembersClone!.push(memberId);
-    guild.members = guildMembersClone;
-    guild.save();
   }
 
   member.tokensLocked = contract.votingPowerOf(event.params.voter);
@@ -262,19 +258,6 @@ export function handleTokenWithdrawal(event: TokensWithdrawn): void {
   let member = Member.load(memberId);
 
   member!.tokensLocked = contract.votingPowerOf(event.params.voter);
-
-  if (member!.tokensLocked == new BigInt(0)) {
-    let guildMembersClone = guild.members;
-    for (let i = 0; i < guildMembersClone!.length; i++) {
-      if (guildMembersClone![i] == memberId) {
-        guildMembersClone!.splice(i, 1);
-      }
-    }
-    guild.members = guildMembersClone;
-
-    guild.save();
-    member!.unset(memberId);
-  }
 }
 
 function isIPFS(contentHash: string): boolean {

--- a/apps/guilds-subgraph/src/mappings/BaseERC20Guild/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/BaseERC20Guild/mapping.ts
@@ -73,9 +73,6 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
     proposal.title = proposalData.title;
     proposal.contentHash = proposalData.contentHash;
     proposal.totalVotes = proposalData.totalVotes;
-    proposal.votes = [];
-    proposal.options = [];
-    proposal.statesLog = [];
 
     let voteOptionsLabel: string[] = [];
 
@@ -115,12 +112,7 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
 
     for (let i = 0; i < amountOfOptions; i++) {
       let optionId = `${proposalId}-${i}`;
-
       let option = new Option(optionId);
-
-      let optionsCopy = proposal.options;
-      optionsCopy!.push(optionId);
-      proposal.options = optionsCopy;
 
       if (voteOptionsLabel.length == amountOfOptions) {
         if (i == 0) {
@@ -132,7 +124,6 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
 
       option.proposalId = proposalId;
       option.actions = [];
-      option.votes = [];
       option.voteAmount = new BigInt(0);
 
       // Skip Option zero and return actions []
@@ -179,14 +170,11 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
   const proposalStateLogId = `${proposalId}-${newState}-${timestamp}`;
 
   let proposalStateLog = new ProposalStateLog(proposalStateLogId);
+  proposalStateLog.proposalId = proposalId;
   proposalStateLog.state = newState;
   proposalStateLog.timestamp = timestamp;
   proposalStateLog.transactionHash = event.transaction.hash.toHexString();
   proposalStateLog.save();
-
-  let proposalStatesLogCopy = proposal.statesLog;
-  proposalStatesLogCopy!.push(proposalStateLogId);
-  proposal.statesLog = proposalStatesLogCopy;
 
   proposal.contractState = newState;
   proposal.save();
@@ -212,18 +200,9 @@ export function handleVoting(event: VoteAdded): void {
     vote = new Vote(voteId);
     vote.proposalId = proposalId;
     vote.option = event.params.option;
+    vote.optionId = optionId;
     vote.optionLabel = option.label;
     vote.voter = event.params.voter.toHexString();
-
-    // Add vote to proposal array. Refactor to use derived entity
-    let votesCopy = proposal.votes;
-    votesCopy!.push(voteId);
-    proposal.votes = votesCopy;
-
-    // Add vote to options array. Refactor to use derived entity
-    let optionVotesCopy = option.votes;
-    optionVotesCopy.push(voteId);
-    option.votes = optionVotesCopy;
   }
 
   vote.votingPower = event.params.votingPower;

--- a/apps/guilds-subgraph/src/mappings/BaseERC20Guild/schema.graphql
+++ b/apps/guilds-subgraph/src/mappings/BaseERC20Guild/schema.graphql
@@ -59,6 +59,7 @@ type Vote @entity {
 
 type Member @entity {
   id: ID!
+  guildId: Guild!
   address: String!
   tokensLocked: BigInt!
 }

--- a/apps/guilds-subgraph/src/mappings/BaseERC20Guild/schema.graphql
+++ b/apps/guilds-subgraph/src/mappings/BaseERC20Guild/schema.graphql
@@ -11,18 +11,18 @@ type Proposal @entity {
   contractState: BigInt!
   guildId: String!
   totalVotes: [BigInt!]
-  votes: [Vote!]
-  options: [Option!]
+  votes: [Vote!] @derivedFrom(field: "proposalId")
+  options: [Option!] @derivedFrom(field: "proposalId")
   snapshotId: BigInt
-  # TODO: use correct metadata type (ProposalMetadata)
   metadata: String
   description: String
   executionTransactionHash: String
-  statesLog: [ProposalStateLog!]
+  statesLog: [ProposalStateLog!] @derivedFrom(field: "proposalId")
 }
 
 type ProposalStateLog @entity {
   id: ID!
+  proposalId: Proposal!
   state: BigInt!
   timestamp: BigInt!
   transactionHash: String!
@@ -31,10 +31,10 @@ type ProposalStateLog @entity {
 type Option @entity {
   id: ID!
   label: String
-  proposalId: String
+  proposalId: Proposal!
   actions: [Action!]
   voteAmount: BigInt
-  votes: [Vote!]!
+  votes: [Vote!] @derivedFrom(field: "optionId")
 }
 
 type Action @entity {
@@ -46,16 +46,11 @@ type Action @entity {
   from: String!
 }
 
-# type ProposalMetadata @entity {
-#   id: ID!
-#   description: String!
-#   voteOptions: [String!]
-# }
-
 type Vote @entity {
   id: ID!
-  proposalId: String!
+  proposalId: Proposal!
   option: BigInt!
+  optionId: Option!
   optionLabel: String
   voter: String!
   votingPower: BigInt!

--- a/apps/guilds-subgraph/src/mappings/BaseERC20Guild/schema.graphql
+++ b/apps/guilds-subgraph/src/mappings/BaseERC20Guild/schema.graphql
@@ -9,7 +9,7 @@ type Proposal @entity {
   title: String!
   contentHash: String!
   contractState: BigInt!
-  guildId: String!
+  guildId: Guild!
   totalVotes: [BigInt!]
   votes: [Vote!] @derivedFrom(field: "proposalId")
   options: [Option!] @derivedFrom(field: "proposalId")

--- a/apps/guilds-subgraph/src/mappings/BaseERC20Guild/schema.graphql
+++ b/apps/guilds-subgraph/src/mappings/BaseERC20Guild/schema.graphql
@@ -32,14 +32,14 @@ type Option @entity {
   id: ID!
   label: String
   proposalId: Proposal!
-  actions: [Action!]
+  actions: [Action!] @derivedFrom(field: "optionId")
   voteAmount: BigInt
   votes: [Vote!] @derivedFrom(field: "optionId")
 }
 
 type Action @entity {
   id: ID!
-  optionId: String!
+  optionId: Option!
   to: String!
   data: String!
   value: BigInt!

--- a/apps/guilds-subgraph/src/mappings/Create2Deployer/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/Create2Deployer/mapping.ts
@@ -45,7 +45,6 @@ export function handleDeployedEvent(event: Deployed): void {
 
     // At this point Guild wasn't initialized so we only create guild with default params
     guild.isActive = false;
-    guild.members = [];
     guild.bytecodeHash = event.params.bytecodeHash.toHexString();
     guild.type = type;
 

--- a/apps/guilds-subgraph/src/mappings/Create2Deployer/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/Create2Deployer/mapping.ts
@@ -45,7 +45,6 @@ export function handleDeployedEvent(event: Deployed): void {
 
     // At this point Guild wasn't initialized so we only create guild with default params
     guild.isActive = false;
-    guild.proposals = [];
     guild.members = [];
     guild.bytecodeHash = event.params.bytecodeHash.toHexString();
     guild.type = type;

--- a/apps/guilds-subgraph/src/mappings/ERC20SnapshotRep/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/ERC20SnapshotRep/mapping.ts
@@ -29,33 +29,15 @@ export function handleTransfer(event: Transfer): void {
 
   if (!member) {
     member = new Member(memberId);
+    member.guildId = token!.guildAddress;
     member.address = event.params.to.toHexString();
     member.tokensLocked = new BigInt(0);
-
-    let guildMembersClone = guild.members;
-    guildMembersClone!.push(memberId);
-    guild.members = guildMembersClone;
-
-    guild.save();
   }
 
   member.tokensLocked = tokenContract.balanceOf(
     Address.fromString(member.address)
   );
 
-  if (member.tokensLocked > new BigInt(0)) {
-    member.save();
-  } else {
-    let guildMembersClone = guild.members;
-    for (let i = 0; i < guildMembersClone!.length; i++) {
-      if (guildMembersClone![i] == memberId) {
-        guildMembersClone!.splice(i, 1);
-      }
-    }
-    guild.members = guildMembersClone;
-
-    guild.save();
-    member.unset(memberId);
-  }
+  member.save();
 }
 

--- a/apps/guilds-subgraph/src/mappings/GuildRegistry/schema.graphql
+++ b/apps/guilds-subgraph/src/mappings/GuildRegistry/schema.graphql
@@ -18,7 +18,7 @@ type Guild @entity {
   type: GuildType
   permissions: [GuildPermission!]! @derivedFrom(field: "guild")
   proposals: [Proposal!] @derivedFrom(field: "guildId")
-  members: [Member!]
+  members: [Member!] @derivedFrom(field: "guildId")
   isActive: Boolean
   bytecodeHash: String
 }

--- a/apps/guilds-subgraph/src/mappings/GuildRegistry/schema.graphql
+++ b/apps/guilds-subgraph/src/mappings/GuildRegistry/schema.graphql
@@ -17,7 +17,7 @@ type Guild @entity {
   minimumTokensLockedForProposalCreation: BigInt
   type: GuildType
   permissions: [GuildPermission!]! @derivedFrom(field: "guild")
-  proposals: [Proposal!]
+  proposals: [Proposal!] @derivedFrom(field: "guildId")
   members: [Member!]
   isActive: Boolean
   bytecodeHash: String

--- a/apps/guilds-subgraph/src/mappings/SnapshotERC20Guild/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/SnapshotERC20Guild/mapping.ts
@@ -264,12 +264,8 @@ export function handleTokenLocking(event: TokensLocked): void {
 
   if (!member) {
     member = new Member(memberId);
+    member.guildId = guildAddress.toHexString();
     member.address = event.params.voter.toHexString();
-
-    let guildMembersClone = guild.members;
-    guildMembersClone!.push(memberId);
-    guild.members = guildMembersClone;
-    guild.save();
   }
 
   member.tokensLocked = contract.votingPowerOf(event.params.voter);
@@ -297,19 +293,6 @@ export function handleTokenWithdrawal(event: TokensWithdrawn): void {
   let member = Member.load(memberId);
 
   member!.tokensLocked = contract.votingPowerOf(event.params.voter);
-
-  if (member!.tokensLocked == new BigInt(0)) {
-    let guildMembersClone = guild.members;
-    for (let i = 0; i < guildMembersClone!.length; i++) {
-      if (guildMembersClone![i] == memberId) {
-        guildMembersClone!.splice(i, 1);
-      }
-    }
-    guild.members = guildMembersClone;
-
-    guild.save();
-    member!.unset(memberId);
-  }
 }
 
 function isIPFS(contentHash: string): boolean {

--- a/apps/guilds-subgraph/src/mappings/SnapshotERC20Guild/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/SnapshotERC20Guild/mapping.ts
@@ -230,45 +230,43 @@ export function handleVoting(event: VoteAdded): void {
   let contract = SnapshotERC20Guild.bind(event.address);
   const proposalData = contract.getProposal(event.params.proposalId);
 
+  let optionId = `${proposalId}-${event.params.option}`;
+  let option = Option.load(optionId);
+  if (!option) return;
+
   let vote = Vote.load(voteId);
   let proposal = Proposal.load(proposalId);
+  if (!proposal) return;
 
+  // Create vote
   if (!vote) {
     vote = new Vote(voteId);
     vote.proposalId = proposalId;
-    vote.voter = event.params.voter.toHexString();
     vote.option = event.params.option;
-    // TODO: check when one voter votes twice
-    if (proposal) {
-      let votesCopy = proposal.votes;
-      votesCopy!.push(voteId);
-      proposal.votes = votesCopy;
+    vote.optionLabel = option.label;
+    vote.voter = event.params.voter.toHexString();
 
-      const newTotalVotes = proposalData.totalVotes;
-      proposal.totalVotes = newTotalVotes;
+    // Add vote to proposal array. Refactor to use derived entity
+    let votesCopy = proposal.votes;
+    votesCopy!.push(voteId);
+    proposal.votes = votesCopy;
 
-      let optionId = `${proposalId}-${event.params.option}`;
-      let option = Option.load(optionId);
-      // update option data on vote event
-      if (!!option) {
-        let optionVotesCopy = option.votes;
-        const newVoteAmount = newTotalVotes[event.params.option.toI32()];
-        optionVotesCopy.push(voteId);
-
-        option.voteAmount = newVoteAmount;
-        option.votes = optionVotesCopy;
-        option.save();
-        vote.optionLabel = option.label;
-      }
-
-      proposal.save();
-    }
+    // Add vote to options array. Refactor to use derived entity
+    let optionVotesCopy = option.votes;
+    optionVotesCopy.push(voteId);
+    option.votes = optionVotesCopy;
   }
-  // TODO: if vote exists update option.voteAmount and push new vote(?)
+
   vote.votingPower = event.params.votingPower;
   vote.transactionHash = event.transaction.hash.toHexString();
-
   vote.save();
+
+  const optionNumber = event.params.option.toI32();
+  option.voteAmount = proposalData.totalVotes[optionNumber];
+  option.save();
+
+  proposal.totalVotes = proposalData.totalVotes;
+  proposal.save();
 }
 
 export function handleTokenLocking(event: TokensLocked): void {

--- a/apps/guilds-subgraph/src/mappings/SnapshotERC20Guild/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/SnapshotERC20Guild/mapping.ts
@@ -184,14 +184,6 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
 
       option.save();
     }
-
-    let guild = Guild.load(address.toHexString());
-    if (guild) {
-      let proposalsCopy = guild.proposals;
-      proposalsCopy!.push(proposalId);
-      guild.proposals = proposalsCopy;
-      guild.save();
-    }
   }
 
   // executed

--- a/apps/guilds-subgraph/src/mappings/SnapshotERC20Guild/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/SnapshotERC20Guild/mapping.ts
@@ -158,8 +158,8 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
       }
 
       option.proposalId = proposalId;
-      option.actions = [];
       option.voteAmount = new BigInt(0);
+      option.save();
 
       // Skip Option zero and return actions []
       if (i > 0) {
@@ -169,20 +169,13 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
           action.optionId = optionId;
           let actionIndex = actionsPerOption * (i - 1) + j;
 
-          if (option.actions) {
-            action.data = data[actionIndex];
-            action.from = address.toHexString();
-            action.to = to[actionIndex];
-            action.value = proposalData.value[actionIndex];
-          }
-          let actionsCopy = option.actions;
-          actionsCopy!.push(actionId);
-          option.actions = actionsCopy;
+          action.data = data[actionIndex];
+          action.from = address.toHexString();
+          action.to = to[actionIndex];
+          action.value = proposalData.value[actionIndex];
           action.save();
         }
       }
-
-      option.save();
     }
   }
 

--- a/apps/guilds-subgraph/src/mappings/SnapshotRepERC20Guild/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/SnapshotRepERC20Guild/mapping.ts
@@ -137,9 +137,6 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
     proposal.contentHash = proposalData.contentHash;
     proposal.totalVotes = proposalData.totalVotes;
     proposal.snapshotId = snapshotId;
-    proposal.votes = [];
-    proposal.options = [];
-    proposal.statesLog = [];
 
     let voteOptionsLabel: string[] = [];
 
@@ -179,12 +176,7 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
 
     for (let i = 0; i < amountOfOptions; i++) {
       let optionId = `${proposalId}-${i}`;
-
       let option = new Option(optionId);
-
-      let optionsCopy = proposal.options;
-      optionsCopy!.push(optionId);
-      proposal.options = optionsCopy;
 
       if (voteOptionsLabel.length == amountOfOptions) {
         if (i == 0) {
@@ -196,7 +188,6 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
 
       option.proposalId = proposalId;
       option.actions = [];
-      option.votes = [];
       option.voteAmount = new BigInt(0);
 
       // Skip Option zero and return actions []
@@ -243,14 +234,11 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
   const proposalStateLogId = `${proposalId}-${newState}-${timestamp}`;
 
   let proposalStateLog = new ProposalStateLog(proposalStateLogId);
+  proposalStateLog.proposalId = proposalId;
   proposalStateLog.state = newState;
   proposalStateLog.timestamp = timestamp;
   proposalStateLog.transactionHash = event.transaction.hash.toHexString();
   proposalStateLog.save();
-
-  let proposalStatesLogCopy = proposal.statesLog;
-  proposalStatesLogCopy!.push(proposalStateLogId);
-  proposal.statesLog = proposalStatesLogCopy;
 
   proposal.contractState = newState;
   proposal.save();
@@ -276,18 +264,9 @@ export function handleVoting(event: VoteAdded): void {
     vote = new Vote(voteId);
     vote.proposalId = proposalId;
     vote.option = event.params.option;
+    vote.optionId = optionId;
     vote.optionLabel = option.label;
     vote.voter = event.params.voter.toHexString();
-
-    // Add vote to proposal array. Refactor to use derived entity
-    let votesCopy = proposal.votes;
-    votesCopy!.push(voteId);
-    proposal.votes = votesCopy;
-
-    // Add vote to options array. Refactor to use derived entity
-    let optionVotesCopy = option.votes;
-    optionVotesCopy.push(voteId);
-    option.votes = optionVotesCopy;
   }
 
   vote.votingPower = event.params.votingPower;

--- a/apps/guilds-subgraph/src/mappings/SnapshotRepERC20Guild/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/SnapshotRepERC20Guild/mapping.ts
@@ -213,14 +213,6 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
 
       option.save();
     }
-
-    let guild = Guild.load(address.toHexString());
-    if (guild) {
-      let proposalsCopy = guild.proposals;
-      proposalsCopy!.push(proposalId);
-      guild.proposals = proposalsCopy;
-      guild.save();
-    }
   }
 
   // executed

--- a/apps/guilds-subgraph/src/mappings/SnapshotRepERC20Guild/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/SnapshotRepERC20Guild/mapping.ts
@@ -263,46 +263,43 @@ export function handleVoting(event: VoteAdded): void {
   let contract = SnapshotRepERC20Guild.bind(event.address);
   const proposalData = contract.getProposal(event.params.proposalId);
 
+  let optionId = `${proposalId}-${event.params.option}`;
+  let option = Option.load(optionId);
+  if (!option) return;
+
   let vote = Vote.load(voteId);
   let proposal = Proposal.load(proposalId);
+  if (!proposal) return;
 
+  // Create vote
   if (!vote) {
     vote = new Vote(voteId);
     vote.proposalId = proposalId;
-    vote.voter = event.params.voter.toHexString();
-    // TODO: change to event.params.option when merging refactor branch of dxdao-contracts
     vote.option = event.params.option;
-    // TODO: check when one voter votes twice
-    if (proposal) {
-      let votesCopy = proposal.votes;
-      votesCopy!.push(voteId);
-      proposal.votes = votesCopy;
+    vote.optionLabel = option.label;
+    vote.voter = event.params.voter.toHexString();
 
-      const newTotalVotes = proposalData.totalVotes;
-      proposal.totalVotes = newTotalVotes;
+    // Add vote to proposal array. Refactor to use derived entity
+    let votesCopy = proposal.votes;
+    votesCopy!.push(voteId);
+    proposal.votes = votesCopy;
 
-      let optionId = `${proposalId}-${event.params.option}`;
-      let option = Option.load(optionId);
-      // update option data on vote event
-      if (!!option) {
-        let optionVotesCopy = option.votes;
-        const newVoteAmount = newTotalVotes[event.params.option.toI32()];
-        optionVotesCopy.push(voteId);
-
-        option.voteAmount = newVoteAmount;
-        option.votes = optionVotesCopy;
-        option.save();
-        vote.optionLabel = option.label;
-      }
-
-      proposal.save();
-    }
+    // Add vote to options array. Refactor to use derived entity
+    let optionVotesCopy = option.votes;
+    optionVotesCopy.push(voteId);
+    option.votes = optionVotesCopy;
   }
-  // TODO: if vote exists update option.voteAmount and push new vote(?)
+
   vote.votingPower = event.params.votingPower;
   vote.transactionHash = event.transaction.hash.toHexString();
-
   vote.save();
+
+  const optionNumber = event.params.option.toI32();
+  option.voteAmount = proposalData.totalVotes[optionNumber];
+  option.save();
+
+  proposal.totalVotes = proposalData.totalVotes;
+  proposal.save();
 }
 
 export function handleTokenLocking(event: TokensLocked): void {

--- a/apps/guilds-subgraph/src/mappings/SnapshotRepERC20Guild/mapping.ts
+++ b/apps/guilds-subgraph/src/mappings/SnapshotRepERC20Guild/mapping.ts
@@ -183,8 +183,8 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
       }
 
       option.proposalId = proposalId;
-      option.actions = [];
       option.voteAmount = new BigInt(0);
+      option.save();
 
       // Skip Option zero and return actions []
       if (i > 0) {
@@ -194,20 +194,13 @@ export function handleProposalStateChange(event: ProposalStateChanged): void {
           action.optionId = optionId;
           let actionIndex = actionsPerOption * (i - 1) + j;
 
-          if (option.actions) {
-            action.data = data[actionIndex];
-            action.from = address.toHexString();
-            action.to = to[actionIndex];
-            action.value = proposalData.value[actionIndex];
-          }
-          let actionsCopy = option.actions;
-          actionsCopy!.push(actionId);
-          option.actions = actionsCopy;
+          action.data = data[actionIndex];
+          action.from = address.toHexString();
+          action.to = to[actionIndex];
+          action.value = proposalData.value[actionIndex];
           action.save();
         }
       }
-
-      option.save();
     }
   }
 


### PR DESCRIPTION
# Description

Increasing the voting power now updates the total votes of the proposal and option.

(disregard the window showing the vote impact since this video is done hardcoding the voting power since the feature it's not implemented)

https://www.loom.com/share/fc38d581da884b65a4c2424a28bd5332

Also, there are quite a lot of changes due to a refactor to use `@derivedFrom` property to make the relationships between entities instead of copying and pushing to an array.

Members that have 0 voting power aren't deleted since that might break when trying to query votes of a member that is no longer active. Updated the `useGetMemberList` query to reflect that change.

Closes #249 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing. Every entity is the same before and after the changes.

To test it, you should hardcode the voting power of the `setVote` function and modify the code to allow you to keep voting after a member has already voted.

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any UI changes have been tested and made responsive for mobile views
