### PR TITLE
Fix 255 - Dragging and dropping of actions between options crash the app 

### DIFF
--- a/apps/davi/src/stores/modules/guilds/common/fetchers/rpc/useGetPermissions/useGetPermissions.tsx
+++ b/apps/davi/src/stores/modules/guilds/common/fetchers/rpc/useGetPermissions/useGetPermissions.tsx
@@ -14,7 +14,7 @@ export const useGetPermissions: IUseGetPermissions = (
 ) => {
   const { data: guildConfig } = useGuildConfig(daoAddress);
 
-  const { from, to, functionSignature } = permissionArgs;
+  const { from, to, functionSignature } = permissionArgs || {};
 
   // The type castings are there because, if we use template literals
   // in the permissionArgs, it leads to the whole app needing 0x${string} types.


### PR DESCRIPTION
# Description

permissionArgs where temporarily undefined and that made the destructuring crash. 

https://user-images.githubusercontent.com/5303411/224707844-0be5f235-3a99-40e1-af16-bff52ebf8bbf.mov

Closes #255 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested by going to create proposal, creating a new option, adding an Action to the "For" option and dragging it to the new option created.
I tried it also with a not allowes action and should work well. 

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
