### PR TITLE
fix: take me home button redirects to correct chain

### DIFF
--- a/apps/davi/src/Modules/Guilds/pages/NotFound.tsx
+++ b/apps/davi/src/Modules/Guilds/pages/NotFound.tsx
@@ -4,19 +4,18 @@ import { StyledLink } from 'components/primitives/Links';
 import { FiArrowLeft } from 'react-icons/fi';
 
 import { useTranslation } from 'react-i18next';
-import { useTypedParams } from 'Modules/Guilds/Hooks/useTypedParams';
+import { useNetwork } from 'wagmi';
 
 const NotFound: React.FC = () => {
-  const { chainName } = useTypedParams();
   const { t } = useTranslation();
-
+  const { chain } = useNetwork();
   return (
     <Result
       state={ResultState.ERROR}
       title={t('404.pageNotExist')}
       subtitle={t('404.makeSureCorrectAddress')}
       extra={
-        <StyledLink to={chainName ? `/${chainName}` : '/'}>
+        <StyledLink to={`/${chain?.name.toLowerCase()}`}>
           <IconButton iconLeft>
             <FiArrowLeft /> {t('404.takeMeHome')}
           </IconButton>


### PR DESCRIPTION
# Description

Take me home-button now redirects to `/{chainName` from the **NotFound**-page

Closes #231 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [ ] My code follows the existing style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
