### PR TITLE
Fix/274 only creator should see edit button on discussion

### DIFF
--- a/apps/davi/src/Modules/Guilds/pages/Discussion/Discussion.tsx
+++ b/apps/davi/src/Modules/Guilds/pages/Discussion/Discussion.tsx
@@ -95,9 +95,8 @@ const DiscussionPage: React.FC = () => {
                 {guildConfig?.name}
               </IconButton>
             </StyledLink>
-
-            {isCreator && (
-              <ButtonContainer>
+            <ButtonContainer>
+              {isCreator && (
                 <StyledLink
                   to={`/${chainName}/${guildId}/discussion/${discussionId}/edit`}
                 >
@@ -108,18 +107,18 @@ const DiscussionPage: React.FC = () => {
                     {t('editDiscussion.editDiscussion')}
                   </Button>
                 </StyledLink>
-                <StyledLink
-                  to={`/${chainName}/${guildId}/create-proposal?ref=${discussionId}`}
+              )}
+              <StyledLink
+                to={`/${chainName}/${guildId}/create-proposal?ref=${discussionId}`}
+              >
+                <Button
+                  variant="primaryWithBorder"
+                  data-testid="create-proposal-button"
                 >
-                  <Button
-                    variant="primaryWithBorder"
-                    data-testid="create-proposal-button"
-                  >
-                    {t('createProposal.createProposal')}
-                  </Button>
-                </StyledLink>
-              </ButtonContainer>
-            )}
+                  {t('createProposal.createProposal')}
+                </Button>
+              </StyledLink>
+            </ButtonContainer>
           </HeaderTopRow>
           <TitleContainer>
             <PageTitle data-testid="discussion-page-title">

--- a/apps/davi/src/Modules/Guilds/pages/Discussion/Discussion.tsx
+++ b/apps/davi/src/Modules/Guilds/pages/Discussion/Discussion.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import AddressButton from 'components/AddressButton/AddressButton';
 import { ProposalDescription } from 'components/ProposalDescription';
 import { StyledLink } from 'components/primitives/Links';
@@ -29,10 +29,12 @@ import PostActions from 'components/Discussion/Post/PostActions';
 import moment from 'moment';
 import { Button, IconButton } from 'components/primitives/Button';
 import { linkStyles } from '../Proposal/Proposal.styled';
+import { useAccount } from 'wagmi';
 
 const DiscussionPage: React.FC = () => {
   const { t } = useTranslation();
   const { chainName, guildId, discussionId } = useTypedParams();
+  const { address: addressConnected } = useAccount();
 
   const [op, setOp] = useState<IOrbisPost>();
   const {
@@ -67,6 +69,12 @@ const DiscussionPage: React.FC = () => {
     }
   };
 
+  const isCreator = useMemo(() => {
+    return (
+      addressConnected.toLowerCase() === op?.creator_details.metadata?.address
+    );
+  }, [addressConnected, op?.creator_details.metadata?.address]);
+
   return (
     <PageContainer>
       <PageContent>
@@ -88,28 +96,30 @@ const DiscussionPage: React.FC = () => {
               </IconButton>
             </StyledLink>
 
-            <ButtonContainer>
-              <StyledLink
-                to={`/${chainName}/${guildId}/discussion/${discussionId}/edit`}
-              >
-                <Button
-                  variant="primaryWithBorder"
-                  data-testid="edit-proposal-button"
+            {isCreator && (
+              <ButtonContainer>
+                <StyledLink
+                  to={`/${chainName}/${guildId}/discussion/${discussionId}/edit`}
                 >
-                  {t('editDiscussion.editDiscussion')}
-                </Button>
-              </StyledLink>
-              <StyledLink
-                to={`/${chainName}/${guildId}/create-proposal?ref=${discussionId}`}
-              >
-                <Button
-                  variant="primaryWithBorder"
-                  data-testid="create-proposal-button"
+                  <Button
+                    variant="primaryWithBorder"
+                    data-testid="edit-proposal-button"
+                  >
+                    {t('editDiscussion.editDiscussion')}
+                  </Button>
+                </StyledLink>
+                <StyledLink
+                  to={`/${chainName}/${guildId}/create-proposal?ref=${discussionId}`}
                 >
-                  {t('createProposal.createProposal')}
-                </Button>
-              </StyledLink>
-            </ButtonContainer>
+                  <Button
+                    variant="primaryWithBorder"
+                    data-testid="create-proposal-button"
+                  >
+                    {t('createProposal.createProposal')}
+                  </Button>
+                </StyledLink>
+              </ButtonContainer>
+            )}
           </HeaderTopRow>
           <TitleContainer>
             <PageTitle data-testid="discussion-page-title">

--- a/apps/davi/src/Modules/Guilds/pages/EditDiscussion.tsx
+++ b/apps/davi/src/Modules/Guilds/pages/EditDiscussion.tsx
@@ -23,6 +23,7 @@ import { WalletModal } from 'components/Web3Modals';
 import { useAccount } from 'wagmi';
 import { isReadOnly } from 'provider/wallets';
 import { NotificationHeading } from 'components/ToastNotifications/NotificationHeading';
+import { IOrbisPost } from 'types/types.orbis';
 
 const EditDiscussionPage: React.FC = () => {
   const { orbis } = useOrbisContext();
@@ -40,6 +41,7 @@ const EditDiscussionPage: React.FC = () => {
   const [html, onHTMLChange] = useState<string>();
   const [initialDescription, setInitialDescription] = useState<string>('');
   const [isWalletModalOpen, setIsWalletModalOpen] = useState(false);
+  const [post, setPost] = useState<IOrbisPost>();
 
   const theme = useTheme();
 
@@ -47,6 +49,7 @@ const EditDiscussionPage: React.FC = () => {
     connector,
     isConnecting: isWalletConnecting,
     isConnected: isWalletConnected,
+    address: addressConnected,
   } = useAccount();
 
   useEffect(() => {
@@ -63,14 +66,24 @@ const EditDiscussionPage: React.FC = () => {
 
   const getPost = async () => {
     const { data } = await orbis.getPost(discussionId);
-    setTitle(data?.content?.title);
-    setInitialDescription(data?.content?.body);
+    setPost(data);
   };
+
+  const isCreator = useMemo(() => {
+    return (
+      addressConnected.toLowerCase() === post?.creator_details.metadata?.address
+    );
+  }, [addressConnected, post]);
 
   useEffect(() => {
     getPost();
+    if (post && !isCreator) {
+      navigate(`/${chain}/${guildId}/discussion/${discussionId}`);
+    }
+    setTitle(post?.content?.title);
+    setInitialDescription(post?.content?.body);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [post]);
 
   const {
     Editor,


### PR DESCRIPTION
# Description

Only creator of discussion should be able to see the edit button on discussion: 
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/5303411/225347158-fd21bad6-0cf0-4375-8c63-bc04f3a81f6b.png">
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/5303411/225347233-e5d90bdf-04bc-45a3-9592-9d4483358746.png">

Closes #274 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

open a discussion and try to edit it with the creator and with another address that's not the creator .

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
