### PR TITLE
fix: variable to match Mint ABI

### DIFF
--- a/apps/davi/src/components/ActionsBuilder/SupportedActions/RepMint/RepMintEditor.tsx
+++ b/apps/davi/src/components/ActionsBuilder/SupportedActions/RepMint/RepMintEditor.tsx
@@ -73,7 +73,7 @@ export const Mint: React.FC<ActionEditorProps> = ({
         ...decodedCall,
         args: {
           ...decodedCall.args,
-          to: values.recipient,
+          account: values.recipient,
           amount: ethers.utils.parseUnits(repAmount.toString()),
         },
       },
@@ -151,7 +151,7 @@ export const Mint: React.FC<ActionEditorProps> = ({
         <ControlRow>
           <Control>
             <ControlLabel>
-              {t('repMint.repAmount')}
+              {t('actionBuilder.repMint.repAmount')}
               <Tooltip text={t('actionBuilder.repMint.repAmountTooltip')}>
                 <StyledIcon src={Info} />
               </Tooltip>

--- a/apps/davi/src/components/ActionsBuilder/SupportedActions/RepMint/__snapshots__/RepMintEditor.test.tsx.snap
+++ b/apps/davi/src/components/ActionsBuilder/SupportedActions/RepMint/__snapshots__/RepMintEditor.test.tsx.snap
@@ -346,7 +346,7 @@ exports[`RepMintEditor Should match snapshot 1`] = `
         <div
           class="c0 c2"
         >
-          repMint.repAmount
+          actionBuilder.repMint.repAmount
           <span
             class="c3"
           >


### PR DESCRIPTION
# Description
The app started to crash whenever the user tried to choose the Mint option and save—turned out to be a variable change in the Mint ABI that caused this to happen.

Closes #312 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually and snapshot.

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any UI changes have been tested and made responsive for mobile views
