### PR TITLE
Fix: approval call was incorrectly decoded

### DIFF
--- a/apps/davi/src/components/ActionsBuilder/SupportedActions/GenericCall/GenericCallParamsMatcher.tsx
+++ b/apps/davi/src/components/ActionsBuilder/SupportedActions/GenericCall/GenericCallParamsMatcher.tsx
@@ -44,7 +44,7 @@ export const renderGenericCallParamValue = (
       return `${param.value}`;
     case 'tokenAmount':
       // TODO: Handle number of decimals better
-      const number = BigNumber.from(param.value);
+      const number = BigNumber.from(param.value ?? 0);
       let formatted = Number.parseFloat(formatUnits(number, 18));
       return Math.round(formatted * Math.pow(10, 4)) / Math.pow(10, 4);
     case 'contentHash':

--- a/apps/davi/src/utils/encodingCalls.ts
+++ b/apps/davi/src/utils/encodingCalls.ts
@@ -102,7 +102,7 @@ export const encodeActions = async (
           ...newCall,
           approval: {
             ...decodedApprovalCall,
-            amount: decodedApprovalCall?.args?._value,
+            amount: decodedApprovalCall?.args?.amount,
             token: decodedApprovalCall?.to,
           },
         };


### PR DESCRIPTION
# Description

Approval call was incorrectly decoded, returning an undefined `amount` value.

Now it will decode it correctly, and in case it doesn't, it will return zero instead of crashing.

Closes #335 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Go to this proposal to test the fix:

http://localhost:3000/#/gnosis/0x3f842726188FcD932d43bcA291be28138228e6D9/proposal/0xd0d2b3959f717a877344d81bdd46d5ab60de1105be7b465e807a3b8016c5e46a

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any UI changes have been tested and made responsive for mobile views
